### PR TITLE
More TensorCPU optimizations

### DIFF
--- a/brain4j-core/build.gradle
+++ b/brain4j-core/build.gradle
@@ -21,5 +21,5 @@ shadowJar {
 }
 
 tasks.withType(JavaExec).configureEach {
-    jvmArgs(['--add-modules', 'jdk.incubator.vector'])
+    jvmArgs(['--add-modules', 'jdk.incubator.vector', '-XX:+UseSerialGC'])
 }

--- a/brain4j-math/src/main/java/org/brain4j/math/tensor/impl/TensorCPU.java
+++ b/brain4j-math/src/main/java/org/brain4j/math/tensor/impl/TensorCPU.java
@@ -791,22 +791,12 @@ public class TensorCPU implements Cloneable, Tensor {
 
     @Override
     public Tensor pow(double value) {
-        for (int i = 0; i < data.length; i++) {
-            data[i] = (float) Math.pow(data[i], value);
-        }
-
-        return this;
+        return map(data -> Math.pow(data, value));
     }
 
     @Override
     public Tensor pow(Tensor other) {
-        checkSameShape(other);
-
-        for (int i = 0; i < data.length; i++) {
-            data[i] = (float) Math.pow(data[i], other.getData()[i]);
-        }
-
-        return this;
+        return mapWithIndex((i, data) -> (float) Math.pow(data, other.getData()[i]));
     }
 
     @Override

--- a/brain4j-math/src/main/java/org/brain4j/math/tensor/impl/TensorCPU.java
+++ b/brain4j-math/src/main/java/org/brain4j/math/tensor/impl/TensorCPU.java
@@ -125,17 +125,15 @@ public class TensorCPU implements Cloneable, Tensor {
 
     public static Tensor of(int[] shape, float... data) {
         Tensor tensor = new TensorCPU(shape);
-        
-        for (int i = 0; i < data.length; i++) {
-            tensor.getData()[i] = data[i];
-        }
+
+        System.arraycopy(data, 0, tensor.getData(), 0, data.length);
         
         return tensor;
     }
     
     public static Tensor of(int[] shape, double... data) {
         Tensor tensor = new TensorCPU(shape);
-        
+
         for (int i = 0; i < data.length; i++) {
             tensor.getData()[i] = (float) data[i];
         }


### PR DESCRIPTION
Further improvements to execution speed when using the cpu implementation.

**NOTE:** There is a performance regression in the current version of brain4j (2.9.0) compared to the one used for pull request #15: TensorCPU#pow has been replaced with a sequential implementation instead of using TensorCPU#map

Example benchmarks running [MNISTExample](https://github.com/RaynLegends/brain4j/blob/127c308e4a8bc246f972b695bcd64983a251e780/brain4j-core/src/test/java/mnist/MNISTExample.java) on an i7 14700k with 32GB DDR5 @ 7200Mhz:
| Version | Time |
| -------- | ------ |
| 2.9.0     | 0.99s |
| Fork | 0.69s |

## Updates
- Use system.arraycopy when possible
- Rewrite TensorCPU#transpose, greatly reducing the number of multiplications needed
- Rewrite TensorCPU#sumAlongDimensions, making it non-recursive
- Improvements to ParallelMap and ParallelMatMul:
  - Better splitting of sequential and parallel work selection
  - Initial task splitting done directly in the main thread instead of waiting for the first task execution
- Revert TensorCPU#pow back to the map implementation
- Use SerialGC when testing

## Potential impacts
No regressions have been found. Benchmarks where made with the vector api available.
I was already using SerialGC because of its great performance for cpu-heavy computations, so I think it's better to make it the default for tasks, but be welcome to revert that change. Applications using brain4j as a library for some features may not want to use that GC, while programs made specifically to train/using mainly brain4j should probably use SerialGC.